### PR TITLE
Disable `YouTubeWidget` on iOS

### DIFF
--- a/lib/src/widgets/html.dart
+++ b/lib/src/widgets/html.dart
@@ -1,4 +1,5 @@
 import 'dart:convert';
+import 'dart:io';
 
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
@@ -131,7 +132,7 @@ class TinhteWidgetFactory extends WidgetFactory {
         final url = constructFullUrl(a['href']);
         if (url?.isEmpty != false) return null;
 
-        final youtubeId = a.containsKey('data-chr-thumbnail')
+        final youtubeId = !Platform.isIOS && a.containsKey('data-chr-thumbnail')
             ? RegExp(r'^https://img.youtube.com/vi/([^/]+)/0.jpg$')
                 .firstMatch(a['data-chr-thumbnail'])
                 ?.group(1)


### PR DESCRIPTION
iOS play inline video in fullscreen so the UX is pretty decent. Performance of `WebView` is still worse than our own `YouTubeWidget` but it's a good trade off.

Android doesn't allow video to go fullscreen so our workaround is still needed.