### PR TITLE
Render placeholder for better Hero animation

### DIFF
--- a/lib/src/widgets/home/thread.dart
+++ b/lib/src/widgets/home/thread.dart
@@ -66,10 +66,8 @@ class HomeThreadWidget extends StatelessWidget {
   Widget _buildImage(double imageScale) => ClipRRect(
         borderRadius: BorderRadius.circular(3),
         child: SizedBox(
-          child: ThreadImageWidget(
-            image: thread.threadThumbnail ?? getThreadImage(thread),
-            threadId: thread.threadId,
-          ),
+          child: ThreadImageWidget.small(
+              thread, thread.threadThumbnail ?? getThreadImage(thread)),
           width: kThreadThumbnailWidth * imageScale,
         ),
       );

--- a/lib/src/widgets/home/top_5.dart
+++ b/lib/src/widgets/home/top_5.dart
@@ -123,10 +123,8 @@ class _HomeTop5WidgetThread extends StatelessWidget {
   Widget _buildImage() => ClipRRect(
         borderRadius: BorderRadius.circular(3),
         child: LayoutBuilder(
-          builder: (context, box) => ThreadImageWidget(
-            image: _chooseImageForBox(thread, context, box),
-            threadId: thread.threadId,
-          ),
+          builder: (context, box) => ThreadImageWidget.small(
+              thread, _chooseImageForBox(thread, context, box)),
         ),
       );
 

--- a/lib/src/widgets/image.dart
+++ b/lib/src/widgets/image.dart
@@ -114,9 +114,14 @@ class ThreadImageWidget extends StatelessWidget {
     );
   }
 
-  static void syncThreadImages(Thread oldThread, Thread newThread) {
-    _smalls[newThread] = _smalls[oldThread];
-  }
+  /// Copies saved image from old thread to the new one.
+  ///
+  /// This is needed because internally an `[Expando]` is used
+  /// to keep track of images without hogging memory.
+  ///
+  /// See [_smalls].
+  static void syncImages(Thread oldThread, Thread newThread) =>
+      _smalls[newThread] = _smalls[oldThread];
 
   static Widget _buildImage(String url, {ImageFrameBuilder frameBuilder}) =>
       Image(

--- a/lib/src/widgets/image.dart
+++ b/lib/src/widgets/image.dart
@@ -43,14 +43,37 @@ String getResizedUrl({
 class ThreadImageWidget extends StatelessWidget {
   final int threadId;
   final ThreadImage image;
+  final ThreadImage placeholder;
   final bool useImageRatio;
 
-  ThreadImageWidget({
+  static final _smalls = Expando<ThreadImage>();
+
+  ThreadImageWidget._({
     @required this.image,
     Key key,
+    this.placeholder,
     @required this.threadId,
     this.useImageRatio = false,
   }) : super(key: key);
+
+  factory ThreadImageWidget.small(Thread thread, ThreadImage image,
+      {bool useImageRatio = false}) {
+    _smalls[thread] = image;
+
+    return ThreadImageWidget._(
+      image: image,
+      threadId: thread.threadId,
+      useImageRatio: useImageRatio,
+    );
+  }
+
+  factory ThreadImageWidget.big(Thread thread, ThreadImage image) =>
+      ThreadImageWidget._(
+        image: image,
+        placeholder: _smalls[thread],
+        threadId: thread.threadId,
+        useImageRatio: true,
+      );
 
   @override
   Widget build(BuildContext context) {
@@ -63,9 +86,19 @@ class ThreadImageWidget extends StatelessWidget {
       );
     }
 
-    final img = Image(
-      image: CachedNetworkImageProvider(link),
-      fit: BoxFit.cover,
+    final placeholder =
+        this.placeholder != null && this.placeholder.link != link
+            ? _buildImage(this.placeholder.link)
+            : null;
+
+    final img = _buildImage(
+      link,
+      frameBuilder: placeholder != null
+          ? (_, child, frame, wasSynchronouslyLoaded) {
+              if (wasSynchronouslyLoaded) return child;
+              return frame != null ? child : placeholder;
+            }
+          : null,
     );
 
     return AspectRatio(
@@ -80,4 +113,15 @@ class ThreadImageWidget extends StatelessWidget {
           : img,
     );
   }
+
+  static void syncThreadImages(Thread oldThread, Thread newThread) {
+    _smalls[newThread] = _smalls[oldThread];
+  }
+
+  static Widget _buildImage(String url, {ImageFrameBuilder frameBuilder}) =>
+      Image(
+        frameBuilder: frameBuilder,
+        image: CachedNetworkImageProvider(url),
+        fit: BoxFit.cover,
+      );
 }

--- a/lib/src/widgets/post/first.dart
+++ b/lib/src/widgets/post/first.dart
@@ -58,10 +58,7 @@ class _FirstPostWidget extends StatelessWidget {
     if (!_isCustomPost && _threadImage?.displayMode == 'cover') {
       widget = Column(
         children: <Widget>[
-          ThreadImageWidget(
-            image: _threadImage,
-            threadId: thread.threadId,
-          ),
+          ThreadImageWidget.big(thread, _threadImage),
           widget,
         ],
       );

--- a/lib/src/widgets/post/list.dart
+++ b/lib/src/widgets/post/list.dart
@@ -207,7 +207,7 @@ class PostsState extends State<PostsWidget> {
     if (json.containsKey('thread')) {
       final thread = Thread.fromJson(json['thread']);
       setState(() {
-        ThreadImageWidget.syncThreadImages(_thread, thread);
+        ThreadImageWidget.syncImages(_thread, thread);
         _thread = thread;
 
         if (fc.id == FetchContextId.FetchInitial &&

--- a/lib/src/widgets/post/list.dart
+++ b/lib/src/widgets/post/list.dart
@@ -207,6 +207,7 @@ class PostsState extends State<PostsWidget> {
     if (json.containsKey('thread')) {
       final thread = Thread.fromJson(json['thread']);
       setState(() {
+        ThreadImageWidget.syncThreadImages(_thread, thread);
         _thread = thread;
 
         if (fc.id == FetchContextId.FetchInitial &&

--- a/lib/src/widgets/thread/widget.dart
+++ b/lib/src/widgets/thread/widget.dart
@@ -106,11 +106,7 @@ class ThreadWidget extends StatelessWidget {
         image.height != null &&
         image.height > image.width) return null;
 
-    return ThreadImageWidget(
-      image: image,
-      threadId: thread.threadId,
-      useImageRatio: true,
-    );
+    return ThreadImageWidget.small(thread, image, useImageRatio: true);
   }
 
   Widget _buildInfo(BuildContext context) {

--- a/lib/src/widgets/tinhte/tinhte_fact.dart
+++ b/lib/src/widgets/tinhte/tinhte_fact.dart
@@ -61,11 +61,7 @@ class TinhteFact extends StatelessWidget {
               textAlign: TextAlign.center,
             ),
           ),
-          ThreadImageWidget(
-            image: thread.threadImage,
-            threadId: thread.threadId,
-            useImageRatio: true,
-          ),
+          ThreadImageWidget.big(thread, thread.threadImage),
           TinhteHtmlWidget(
             "<center>$postBodyHtml</center>",
             textStyle: theme.textTheme.bodyText2,


### PR DESCRIPTION
This app uses the Hero widget to animate thread image between list view and thread detailed view. 
The list view usually uses a thumbnail making it ugly when the hero animation happens because the full image is still loading at that time. If user taps the same thread again, the animation is better because the full image has been cached.

This PR attempts to improve that by using the thumbnail image as a placeholder while the full one is downloading. See the comparison to understand it better:

https://youtu.be/0QVNlsmrXvs