### PR TITLE
Improve iOS build time

### DIFF
--- a/.github/workflows/flutter.yml
+++ b/.github/workflows/flutter.yml
@@ -85,7 +85,7 @@ jobs:
         run: |
           set -e
 
-          flutter build ios "--build-name=${BUILD_NAME}" --no-codesign
+          flutter build ios "--build-name=${BUILD_NAME}" || true
           ( cd ios && fastlane ipa )
 
       - name: Setup GCP authentication


### PR DESCRIPTION
This PR removes `--no-codesign` and lets the initial build fail. Currently the initial build takes 363s then fastlane build takes 232s. I hope to cut the initial build time completely while keeping the fastlane time from jumping too much.